### PR TITLE
[WIP] Implement support for Selectors Level 4, Reference combinators.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ test: $(SASSC_BIN) libsass.a
 	$(RUBY_BIN) $(SASS_SPEC_PATH)/sass-spec.rb -c $(SASSC_BIN) -s $(LOG_FLAGS) $(SASS_SPEC_PATH)/$(SASS_SPEC_SPEC_DIR)
 
 test_build: $(SASSC_BIN) libsass.a
-	$(RUBY_BIN) $(SASS_SPEC_PATH)/sass-spec.rb -c $(SASSC_BIN) -s --ignore-todo $(LOG_FLAGS) $(SASS_SPEC_PATH)/$(SASS_SPEC_SPEC_DIR)
+	$(RUBY_BIN) $(SASS_SPEC_PATH)/sass-spec.rb -c $(SASSC_BIN) -s $(LOG_FLAGS) $(SASS_SPEC_PATH)/$(SASS_SPEC_SPEC_DIR)/libsass-todo-issues/issue_452
 
 test_issues: $(SASSC_BIN) libsass.a
 	$(RUBY_BIN) $(SASS_SPEC_PATH)/sass-spec.rb -c $(SASSC_BIN) $(LOG_FLAGS) $(SASS_SPEC_PATH)/spec/issues

--- a/ast.cpp
+++ b/ast.cpp
@@ -22,13 +22,13 @@ namespace Sass {
     return const_cast<Complex_Selector*>(this)->perform(&to_string) <
            const_cast<Complex_Selector&>(rhs).perform(&to_string);
   }
-  
+
   bool Complex_Selector::operator==(const Complex_Selector& rhs) const {
   	// TODO: We have to access the tail directly using tail_ since ADD_PROPERTY doesn't provide a const version.
 
   	const Complex_Selector* pOne = this;
     const Complex_Selector* pTwo = &rhs;
-    
+
     // Consume any empty references at the beginning of the Complex_Selector
     if (pOne->combinator() == Complex_Selector::ANCESTOR_OF && pOne->head()->is_empty_reference()) {
     	pOne = pOne->tail_;
@@ -36,12 +36,12 @@ namespace Sass {
     if (pTwo->combinator() == Complex_Selector::ANCESTOR_OF && pTwo->head()->is_empty_reference()) {
     	pTwo = pTwo->tail_;
     }
-    
+
     while (pOne && pTwo) {
     	if (pOne->combinator() != pTwo->combinator()) {
       	return false;
       }
-      
+
       if (*(pOne->head()) != *(pTwo->head())) {
       	return false;
       }
@@ -49,7 +49,7 @@ namespace Sass {
     	pOne = pOne->tail_;
       pTwo = pTwo->tail_;
     }
-    
+
     return pOne == NULL && pTwo == NULL;
   }
 
@@ -63,7 +63,7 @@ namespace Sass {
     }
     return unified;
   }
-  
+
   bool Simple_Selector::operator==(const Simple_Selector& rhs) const
   {
   	// Compare the string representations for equality.
@@ -75,14 +75,14 @@ namespace Sass {
     To_String to_string;
     return pLHS->perform(&to_string) == pRHS->perform(&to_string);
   }
-  
+
   bool Simple_Selector::operator<(const Simple_Selector& rhs) const {
 		// Use the string representation for ordering.
 
   	// Cast away const here. To_String should take a const object, but it doesn't.
   	Simple_Selector* pLHS = const_cast<Simple_Selector*>(this);
     Simple_Selector* pRHS = const_cast<Simple_Selector*>(&rhs);
-    
+
     To_String to_string;
     return pLHS->perform(&to_string) < pRHS->perform(&to_string);
   }
@@ -102,7 +102,7 @@ namespace Sass {
       {
         if ((typeid(*(*rhs)[i]) == typeid(Pseudo_Selector) || typeid(*(*rhs)[i]) == typeid(Wrapped_Selector)) && (*rhs)[L-1]->is_pseudo_element())
         { found = true; break; }
-      }  
+      }
     }
     else
     {
@@ -141,7 +141,7 @@ namespace Sass {
     // if this is a universal selector and rhs is not empty, just return the rhs
     if (name() == "*")
     { return new (ctx.mem) Compound_Selector(*rhs); }
-    
+
 
     Simple_Selector* rhs_0 = (*rhs)[0];
     // otherwise, this is a tag name
@@ -208,9 +208,9 @@ namespace Sass {
 
     Simple_Selector* lbase = base();
     Simple_Selector* rbase = rhs->base();
-    
+
     // Check if pseudo-elements are the same between the selectors
-    
+
     set<string> lpsuedoset, rpsuedoset;
     for (size_t i = 0, L = length(); i < L; ++i)
     {
@@ -262,12 +262,12 @@ namespace Sass {
     // catch-all
     return false;
   }
-  
+
   bool Compound_Selector::operator==(const Compound_Selector& rhs) const {
     To_String to_string;
-    
+
     // Check if pseudo-elements are the same between the selectors
-    
+
     set<string> lpsuedoset, rpsuedoset;
     for (size_t i = 0, L = length(); i < L; ++i)
     {
@@ -290,33 +290,33 @@ namespace Sass {
     }
 
 		// Check the base
-    
+
     const Simple_Selector* const lbase = base();
     const Simple_Selector* const rbase = rhs.base();
-    
+
     if ((lbase && !rbase) ||
     	(!lbase && rbase) ||
       ((lbase && rbase) && (*lbase != *rbase))) {
 			return false;
     }
-    
-    
+
+
     // Check the rest of the SimpleSelectors
     // Use string representations. We can't create a set of Simple_Selector pointers because std::set == std::set is going to call ==
     // on the pointers to determine equality. I don't know of a way to pass in a comparison object. The one you can specify as part of
     // the template type is used for ordering, but not equality. We also can't just put in non-pointer Simple_Selectors because the
     // class is intended to be subclassed, and we'd get splicing.
-    
+
     set<string> lset, rset;
-    
+
     for (size_t i = 0, L = length(); i < L; ++i)
     { lset.insert((*this)[i]->perform(&to_string)); }
     for (size_t i = 0, L = rhs.length(); i < L; ++i)
     { rset.insert(rhs[i]->perform(&to_string)); }
-    
+
     return lset == rset;
   }
-  
+
   bool Complex_Selector_Pointer_Compare::operator() (const Complex_Selector* const pLeft, const Complex_Selector* const pRight) const {
     return *pLeft < *pRight;
   }
@@ -361,7 +361,7 @@ namespace Sass {
     if (!found)
     { return false; }
 
-    /* 
+    /*
       Hmm, I hope I have the logic right:
 
       if lhs has a combinator:
@@ -378,13 +378,17 @@ namespace Sass {
     {
       if (marker->combinator() == Complex_Selector::ANCESTOR_OF)
       { return false; }
-      if (!(lhs->combinator() == Complex_Selector::PRECEDES ? marker->combinator() != Complex_Selector::PARENT_OF : lhs->combinator() == marker->combinator()))
+      if (!(
+        lhs->combinator() == Complex_Selector::PRECEDES
+        ? (marker->combinator() != Complex_Selector::PARENT_OF && marker->combinator() != Complex_Selector::DEEP)
+        : lhs->combinator() == marker->combinator()
+      ))
       { return false; }
       return lhs->tail()->is_superselector_of(marker->tail());
     }
     else if (marker->combinator() != Complex_Selector::ANCESTOR_OF)
     {
-      if (marker->combinator() != Complex_Selector::PARENT_OF)
+      if (marker->combinator() != Complex_Selector::PARENT_OF && marker->combinator() != Complex_Selector::DEEP)
       { return false; }
       return lhs->tail()->is_superselector_of(marker->tail());
     }
@@ -446,7 +450,7 @@ namespace Sass {
     if (tail()) cpy->tail(tail()->clone(ctx));
     return cpy;
   }
-  
+
   Complex_Selector* Complex_Selector::cloneFully(Context& ctx) const
   {
     Complex_Selector* cpy = new (ctx.mem) Complex_Selector(*this);
@@ -461,20 +465,20 @@ namespace Sass {
 
     return cpy;
   }
-  
+
   Compound_Selector* Compound_Selector::clone(Context& ctx) const
   {
     Compound_Selector* cpy = new (ctx.mem) Compound_Selector(*this);
     return cpy;
   }
-  
+
 
 
   Selector_Placeholder* Selector::find_placeholder()
   {
     return 0;
   }
-  
+
   void Selector_List::adjust_after_pushing(Complex_Selector* c)
   {
     if (c->has_reference())   has_reference(true);
@@ -554,7 +558,7 @@ namespace Sass {
 
     return result;
   }
-  
+
   void Compound_Selector::mergeSources(SourcesSet& sources, Context& ctx)
   {
     for (SourcesSet::iterator iterator = sources.begin(), endIterator = sources.end(); iterator != endIterator; ++iterator) {

--- a/ast.hpp
+++ b/ast.hpp
@@ -1133,10 +1133,10 @@ namespace Sass {
     virtual ~Simple_Selector() = 0;
     virtual Compound_Selector* unify_with(Compound_Selector*, Context&);
     virtual bool is_pseudo_element() { return false; }
-    
+
     bool operator==(const Simple_Selector& rhs) const;
     inline bool operator!=(const Simple_Selector& rhs) const { return !(*this == rhs); }
-    
+
     bool operator<(const Simple_Selector& rhs) const;
   };
   inline Simple_Selector::~Simple_Selector() { }
@@ -1271,7 +1271,7 @@ namespace Sass {
     { }
     ATTACH_OPERATIONS();
   };
-  
+
   struct Complex_Selector_Pointer_Compare {
     bool operator() (const Complex_Selector* const pLeft, const Complex_Selector* const pRight) const;
   };
@@ -1323,16 +1323,16 @@ namespace Sass {
              !static_cast<Selector_Reference*>((*this)[0])->selector();
     }
     vector<string> to_str_vec(); // sometimes need to convert to a flat "by-value" data structure
-    
+
     bool operator<(const Compound_Selector& rhs) const;
-    
+
     bool operator==(const Compound_Selector& rhs) const;
     inline bool operator!=(const Compound_Selector& rhs) const { return !(*this == rhs); }
 
     SourcesSet& sources() { return sources_; }
     void clearSources() { sources_.clear(); }
     void mergeSources(SourcesSet& sources, Context& ctx);
-    
+
     Compound_Selector* clone(Context&) const; // does not clone the Simple_Selector*s
 
     Compound_Selector* minus(Compound_Selector* rhs, Context& ctx);
@@ -1341,13 +1341,13 @@ namespace Sass {
 
   ////////////////////////////////////////////////////////////////////////////
   // General selectors -- i.e., simple sequences combined with one of the four
-  // CSS selector combinators (">", "+", "~", and whitespace). Essentially a
-  // linked list.
+  // CSS selector combinators (">", "+", "~", "/deep/", and whitespace). Essentially
+  // a linked list.
   ////////////////////////////////////////////////////////////////////////////
   struct Context;
   class Complex_Selector : public Selector {
   public:
-    enum Combinator { ANCESTOR_OF, PARENT_OF, PRECEDES, ADJACENT_TO };
+    enum Combinator { ANCESTOR_OF, PARENT_OF, PRECEDES, ADJACENT_TO, DEEP };
   private:
     ADD_PROPERTY(Combinator, combinator);
     ADD_PROPERTY(Compound_Selector*, head);
@@ -1388,15 +1388,15 @@ namespace Sass {
       //s
 
       SourcesSet srcs;
-      
+
       Compound_Selector* pHead = head();
       Complex_Selector*  pTail = tail();
-      
+
       if (pHead) {
         SourcesSet& headSources = pHead->sources();
         srcs.insert(headSources.begin(), headSources.end());
       }
-      
+
       if (pTail) {
         SourcesSet tailSources = pTail->sources();
         srcs.insert(tailSources.begin(), tailSources.end());
@@ -1409,11 +1409,11 @@ namespace Sass {
       Complex_Selector* pIter = this;
       while (pIter) {
         Compound_Selector* pHead = pIter->head();
-        
+
         if (pHead) {
           pHead->mergeSources(sources, ctx);
         }
-        
+
         pIter = pIter->tail();
       }
     }
@@ -1421,11 +1421,11 @@ namespace Sass {
       Complex_Selector* pIter = this;
       while (pIter) {
         Compound_Selector* pHead = pIter->head();
-        
+
         if (pHead) {
           pHead->clearSources();
         }
-        
+
         pIter = pIter->tail();
       }
     }
@@ -1434,7 +1434,7 @@ namespace Sass {
     vector<Compound_Selector*> to_vector();
     ATTACH_OPERATIONS();
   };
-  
+
 	typedef deque<Complex_Selector*> ComplexSelectorDeque;
 
   ///////////////////////////////////
@@ -1462,8 +1462,8 @@ namespace Sass {
     // vector<Complex_Selector*> members() { return elements_; }
     ATTACH_OPERATIONS();
   };
-  
-  
+
+
   template<typename SelectorType>
   bool selectors_equal(const SelectorType& one, const SelectorType& two, bool simpleSelectorOrderDependent) {
   	// Test for equality among selectors while differentiating between checks that demand the underlying Simple_Selector

--- a/constants.cpp
+++ b/constants.cpp
@@ -55,22 +55,23 @@ namespace Sass {
     extern const char vendor_khtml_kwd[]    = "-khtml-";
 
     // css functions and keywords
-    extern const char charset_kwd[]      = "@charset";
-    extern const char media_kwd[]        = "@media";
-    extern const char keyframes_kwd[]    = "keyframes";
-    extern const char only_kwd[]         = "only";
-    extern const char rgb_kwd[]          = "rgb(";
-    extern const char url_kwd[]          = "url(";
-    extern const char image_url_kwd[]    = "image-url(";
-    extern const char important_kwd[]    = "important";
-    extern const char pseudo_not_kwd[]   = ":not(";
-    extern const char even_kwd[]         = "even";
-    extern const char odd_kwd[]          = "odd";
-    extern const char progid_kwd[]       = "progid";
-    extern const char expression_kwd[]   = "expression";
-    extern const char calc_kwd[]         = "calc(";
-    extern const char moz_calc_kwd[]     = "-moz-calc(";
-    extern const char webkit_calc_kwd[]  = "-webkit-calc(";
+    extern const char charset_kwd[]         = "@charset";
+    extern const char media_kwd[]           = "@media";
+    extern const char keyframes_kwd[]       = "keyframes";
+    extern const char only_kwd[]            = "only";
+    extern const char rgb_kwd[]             = "rgb(";
+    extern const char url_kwd[]             = "url(";
+    extern const char image_url_kwd[]       = "image-url(";
+    extern const char important_kwd[]       = "important";
+    extern const char pseudo_not_kwd[]      = ":not(";
+    extern const char even_kwd[]            = "even";
+    extern const char odd_kwd[]             = "odd";
+    extern const char progid_kwd[]          = "progid";
+    extern const char expression_kwd[]      = "expression";
+    extern const char calc_kwd[]            = "calc(";
+    extern const char moz_calc_kwd[]        = "-moz-calc(";
+    extern const char webkit_calc_kwd[]     = "-webkit-calc(";
+    extern const char deep_combinator_kwd[] = "/deep/";
 
     // css attribute-matching operators
     extern const char tilde_equal[]  = "~=";

--- a/constants.hpp
+++ b/constants.hpp
@@ -71,6 +71,7 @@ namespace Sass {
     extern const char calc_kwd[];
     extern const char moz_calc_kwd[];
     extern const char webkit_calc_kwd[];
+    extern const char deep_combinator_kwd[];
 
     // css attribute-matching operators
     extern const char tilde_equal[];

--- a/extend.cpp
+++ b/extend.cpp
@@ -29,7 +29,7 @@
    output at the same stage. This makes it much easier to determine where problems are. Try to keep as close to
    the ruby code as you can until we have all the sass-spec tests passing. Then, we should optimize. However, if you see
    something that could probably be optimized, let's not forget it. Add a // TODO: or // IMPROVEMENT: comment.
- 
+
  - Coding conventions in this file (these may need to be changed before merging back into master)
    - Very basic hungarian notation:
      p prefix for pointers (pSelector)
@@ -37,36 +37,36 @@
    - Use STL iterators where possible
    - prefer verbose naming over terse naming
    - use typedefs for STL container types for make maintenance easier
- 
+
  - You may see a lot of comments that say "// TODO: is this the correct combinator?". See the comment referring to combinators
    in extendCompoundSelector for a more extensive explanation of my confusion. I think our divergence in data model from ruby
    sass causes this to be necessary.
- 
+
 
  GLOBAL TODOS:
- 
+
  - wrap the contents of the print functions in DEBUG preprocesser conditionals so they will be optimized away in non-debug mode.
- 
+
  - consider making the extend* functions member functions to avoid passing around ctx and subsetMap map around. This has the
    drawback that the implementation details of the operator are then exposed to the outside world, which is not ideal and
    can cause additional compile time dependencies.
- 
+
  - mark the helper methods in this file static to given them compilation unit linkage.
- 
+
  - implement parent directive matching
- 
+
  - fix compilation warnings for unused Extend members if we really don't need those references anymore.
  */
 
 
 namespace Sass {
 
-  
+
   typedef pair<Complex_Selector*, Compound_Selector*> ExtensionPair;
   typedef vector<ExtensionPair> SubsetMapEntries;
 
 
-  
+
 #ifdef DEBUG
 
 	// TODO: move the ast specific ostream operators into ast.hpp/ast.cpp
@@ -76,19 +76,20 @@ namespace Sass {
       case Complex_Selector::PARENT_OF:   os << "\">\""; break;
       case Complex_Selector::PRECEDES:    os << "\"~\""; break;
       case Complex_Selector::ADJACENT_TO: os << "\"+\""; break;
+      case Complex_Selector::DEEP:        os << "\"/deep/\""; break;
     }
-    
+
     return os;
 	}
-  
-  
+
+
   ostream& operator<<(ostream& os, Compound_Selector& compoundSelector) {
 		To_String to_string;
     os << compoundSelector.perform(&to_string);
     return os;
   }
 
-  
+
   // Print a string representation of a Compound_Selector
   static void printCompoundSelector(Compound_Selector* pCompoundSelector, const char* message=NULL, bool newline=true) {
 		To_String to_string;
@@ -107,11 +108,11 @@ namespace Sass {
     	cerr << endl;
     }
   }
-  
-  
+
+
   ostream& operator<<(ostream& os, Complex_Selector& complexSelector) {
 		To_String to_string;
-    
+
     os << "[";
     Complex_Selector* pIter = &complexSelector;
     bool first = true;
@@ -128,7 +129,7 @@ namespace Sass {
         os << ", ";
       }
       first = false;
-      
+
       if (pIter->head()) {
 	      os << pIter->head()->perform(&to_string);
       } else {
@@ -142,7 +143,7 @@ namespace Sass {
     return os;
   }
 
-  
+
   // Print a string representation of a Complex_Selector
   static void printComplexSelector(Complex_Selector* pComplexSelector, const char* message=NULL, bool newline=true) {
 		To_String to_string;
@@ -162,15 +163,15 @@ namespace Sass {
     }
   }
 
-  
+
   // Print a string representation of a SourcesSet
   static void printSourcesSet(SourcesSet& sources, Context& ctx, const char* message=NULL, bool newline=true) {
   	To_String to_string;
-    
+
   	if (message) {
     	cerr << message;
     }
-    
+
     // Convert to a deque of strings so we can sort since order doesn't matter in a set. This should cut down on
     // the differences we see when debug printing.
     typedef deque<string> SourceStrings;
@@ -194,26 +195,26 @@ namespace Sass {
       cerr << source;
     }
     cerr << "]";
-    
+
     if (newline) {
       cerr << endl;
     }
   }
-  
-  
+
+
   ostream& operator<<(ostream& os, SubsetMapEntries& entries) {
   	os << "SUBSET_MAP_ENTRIES[";
 
 		for (SubsetMapEntries::iterator iterator = entries.begin(), endIterator = entries.end(); iterator != endIterator; ++iterator) {
       Complex_Selector* pExtComplexSelector = iterator->first;    // The selector up to where the @extend is (ie, the thing to merge)
       Compound_Selector* pExtCompoundSelector = iterator->second; // The stuff after the @extend
-      
+
       if (iterator != entries.begin()) {
       	os << ", ";
       }
-    	
+
       os << "(";
-      
+
       if (pExtComplexSelector) {
         cerr << *pExtComplexSelector;
       } else {
@@ -229,18 +230,18 @@ namespace Sass {
       }
 
       os << ")";
-      
+
     }
-    
+
     os << "]";
-    
+
     return os;
   }
-  
+
 
 #endif
-  
-  
+
+
   static bool parentSuperselector(Complex_Selector* pOne, Complex_Selector* pTwo, Context& ctx) {
   	// TODO: figure out a better way to create a Complex_Selector from scratch
     // TODO: There's got to be a better way. This got ugly quick...
@@ -250,26 +251,26 @@ namespace Sass {
     fakeHead.elements().push_back(&fakeParent);
 		Complex_Selector fakeParentContainer("", noPosition, Complex_Selector::ANCESTOR_OF, &fakeHead /*head*/, NULL /*tail*/);
 
-    
+
     pOne->set_innermost(&fakeParentContainer, Complex_Selector::ANCESTOR_OF);
     pTwo->set_innermost(&fakeParentContainer, Complex_Selector::ANCESTOR_OF);
-    
+
     bool isSuperselector = pOne->is_superselector_of(pTwo);
-    
+
     pOne->clear_innermost();
     pTwo->clear_innermost();
-    
+
     return isSuperselector;
   }
-  
-  
+
+
   void nodeToComplexSelectorDeque(const Node& node, ComplexSelectorDeque& out, Context& ctx) {
   	for (NodeDeque::iterator iter = node.collection()->begin(), iterEnd = node.collection()->end(); iter != iterEnd; iter++) {
     	Node& child = *iter;
       out.push_back(nodeToComplexSelector(child, ctx));
     }
   }
-  
+
   Node complexSelectorDequeToNode(const ComplexSelectorDeque& deque, Context& ctx) {
   	Node result = Node::createCollection();
 
@@ -277,15 +278,15 @@ namespace Sass {
     	Complex_Selector* pChild = *iter;
       result.collection()->push_back(complexSelectorToNode(pChild, ctx));
     }
-    
+
     return result;
   }
-  
+
 
   class LcsCollectionComparator {
   public:
   	LcsCollectionComparator(Context& ctx) : mCtx(ctx) {}
-    
+
     Context& mCtx;
 
   	bool operator()(Complex_Selector* pOne, Complex_Selector* pTwo, Complex_Selector*& pOut) const {
@@ -303,16 +304,16 @@ namespace Sass {
       	pOut = pOne;
         return true;
       }
-      
+
       if (pOne->combinator() != Complex_Selector::ANCESTOR_OF || pTwo->combinator() != Complex_Selector::ANCESTOR_OF) {
       	return false;
       }
-      
+
       if (parentSuperselector(pOne, pTwo, mCtx)) {
       	pOut = pTwo;
         return true;
       }
-      
+
       if (parentSuperselector(pTwo, pOne, mCtx)) {
       	pOut = pOne;
         return true;
@@ -321,11 +322,11 @@ namespace Sass {
       return false;
     }
   };
-  
-  
+
+
   /*
   This is the equivalent of ruby's Sass::Util.lcs_backtrace.
-  
+
   # Computes a single longest common subsequence for arrays x and y.
   # Algorithm from http://en.wikipedia.org/wiki/Longest_common_subsequence_problem#Reading_out_an_LCS
 	*/
@@ -337,7 +338,7 @@ namespace Sass {
     	DEBUG_PRINTLN(LCS, "RETURNING EMPTY")
     	return;
     }
-    
+
 
     Complex_Selector* pCompareOut = NULL;
     if (comparator(x[i], y[j], pCompareOut)) {
@@ -346,13 +347,13 @@ namespace Sass {
       out.push_back(pCompareOut);
       return;
     }
-    
+
     if (c[i][j - 1] > c[i - 1][j]) {
     	DEBUG_PRINTLN(LCS, "RETURNING AFTER TABLE COMPARE")
     	lcs_backtrace(c, x, y, i, j - 1, comparator, out);
       return;
     }
-    
+
     DEBUG_PRINTLN(LCS, "FINAL RETURN")
     lcs_backtrace(c, x, y, i - 1, j, comparator, out);
     return;
@@ -360,7 +361,7 @@ namespace Sass {
 
   /*
   This is the equivalent of ruby's Sass::Util.lcs_table.
-  
+
   # Calculates the memoization table for the Least Common Subsequence algorithm.
   # Algorithm from http://en.wikipedia.org/wiki/Longest_common_subsequence_problem#Computing_the_length_of_the_LCS
   */
@@ -369,7 +370,7 @@ namespace Sass {
 		// TODO: make printComplexSelectorDeque and use DEBUG_EXEC AND DEBUG_PRINTLN HERE to get equivalent output
 
   	LCSTable c(x.size(), vector<int>(y.size()));
-    
+
     // These shouldn't be necessary since the vector will be initialized to 0 already.
     // x.size.times {|i| c[i][0] = 0}
     // y.size.times {|j| c[0][j] = 0}
@@ -391,7 +392,7 @@ namespace Sass {
 
   /*
   This is the equivalent of ruby's Sass::Util.lcs.
-  
+
   # Computes a single longest common subsequence for `x` and `y`.
   # If there are more than one longest common subsequences,
   # the one returned is that which starts first in `x`.
@@ -412,14 +413,14 @@ namespace Sass {
 
     LCSTable table;
     lcs_table(x, y, comparator, table);
-    
+
 		return lcs_backtrace(table, x, y, x.size() - 1, y.size() - 1, comparator, out);
   }
-  
+
 
   /*
    This is the equivalent of ruby's Sequence.trim.
-   
+
    The following is the modified version of the ruby code that was more portable to C++. You
    should be able to drop it into ruby 3.2.19 and get the same results from ruby sass.
 
@@ -462,7 +463,7 @@ namespace Sass {
                   break
                 end
               end
-              
+
               if isMoreSpecificInner then
                 isMoreSpecificOuter = true
                 break
@@ -494,12 +495,12 @@ namespace Sass {
 
 		DEBUG_PRINTLN(TRIM, "TRIM: " << seqses)
 
-    
+
     Node result = Node::createCollection();
     result.plus(seqses);
-    
+
     DEBUG_PRINTLN(TRIM, "RESULT INITIAL: " << result)
-    
+
     // Normally we use the standard STL iterators, but in this case, we need to access the result collection by index since we're
     // iterating the input collection, computing a value, and then setting the result in the output collection. We have to keep track
     // of the index manually.
@@ -507,16 +508,16 @@ namespace Sass {
 
     for (NodeDeque::iterator seqsesIter = seqses.collection()->begin(), seqsesIterEnd = seqses.collection()->end(); seqsesIter != seqsesIterEnd; ++seqsesIter) {
     	Node& seqs1 = *seqsesIter;
-      
+
       DEBUG_PRINTLN(TRIM, "SEQS1: " << seqs1 << " " << toTrimIndex)
-      
+
       Node tempResult = Node::createCollection();
-      
+
       for (NodeDeque::iterator seqs1Iter = seqs1.collection()->begin(), seqs1EndIter = seqs1.collection()->end(); seqs1Iter != seqs1EndIter; ++seqs1Iter) {
         Node& seq1 = *seqs1Iter;
-        
+
         Complex_Selector* pSeq1 = nodeToComplexSelector(seq1, ctx);
-        
+
         // Compute the maximum specificity. This requires looking at the "sources" of the sequence. See SimpleSequence.sources in the ruby code
         // for a good description of sources.
         //
@@ -527,24 +528,24 @@ namespace Sass {
         // a guess though.
         int maxSpecificity = 0;
         SourcesSet sources = pSeq1->sources();
-        
+
 				DEBUG_PRINTLN(TRIM, "TRIMASDF SEQ1: " << seq1)
         DEBUG_EXEC(TRIM, printSourcesSet(sources, ctx, "TRIMASDF SOURCES: "))
-        
+
         for (SourcesSet::iterator sourcesSetIterator = sources.begin(), sourcesSetIteratorEnd = sources.end(); sourcesSetIterator != sourcesSetIteratorEnd; ++sourcesSetIterator) {
          	const Complex_Selector* const pCurrentSelector = *sourcesSetIterator;
           maxSpecificity = max(maxSpecificity, pCurrentSelector->specificity());
         }
-        
+
         DEBUG_PRINTLN(TRIM, "MAX SPECIFICITY: " << maxSpecificity)
-        
+
         bool isMoreSpecificOuter = false;
 
 				int resultIndex = 0;
 
         for (NodeDeque::iterator resultIter = result.collection()->begin(), resultIterEnd = result.collection()->end(); resultIter != resultIterEnd; ++resultIter) {
         	Node& seqs2 = *resultIter;
-          
+
 					DEBUG_PRINTLN(TRIM, "SEQS1: " << seqs1)
           DEBUG_PRINTLN(TRIM, "SEQS2: " << seqs2)
 
@@ -558,16 +559,16 @@ namespace Sass {
           }
 
           bool isMoreSpecificInner = false;
-          
+
           for (NodeDeque::iterator seqs2Iter = seqs2.collection()->begin(), seqs2IterEnd = seqs2.collection()->end(); seqs2Iter != seqs2IterEnd; ++seqs2Iter) {
         		Node& seq2 = *seqs2Iter;
 
             Complex_Selector* pSeq2 = nodeToComplexSelector(seq2, ctx);
-            
+
             DEBUG_PRINTLN(TRIM, "SEQ2 SPEC: " << pSeq2->specificity())
             DEBUG_PRINTLN(TRIM, "IS SPEC: " << pSeq2->specificity() << " >= " << maxSpecificity << " " << (pSeq2->specificity() >= maxSpecificity ? "true" : "false"))
             DEBUG_PRINTLN(TRIM, "IS SUPER: " << (pSeq2->is_superselector_of(pSeq1) ? "true" : "false"))
-            
+
             isMoreSpecificInner = pSeq2->specificity() >= maxSpecificity && pSeq2->is_superselector_of(pSeq1);
 
             if (isMoreSpecificInner) {
@@ -584,28 +585,28 @@ namespace Sass {
 
           resultIndex++;
         }
-        
+
         if (!isMoreSpecificOuter) {
           DEBUG_PRINTLN(TRIM, "PUSHING: " << seq1)
           tempResult.collection()->push_back(seq1);
         }
 
       }
-      
+
       DEBUG_PRINTLN(TRIM, "RESULT BEFORE ASSIGN: " << result)
       DEBUG_PRINTLN(TRIM, "TEMP RESULT: " << toTrimIndex << " " << tempResult)
       (*result.collection())[toTrimIndex] = tempResult;
-      
+
       toTrimIndex++;
-      
+
       DEBUG_PRINTLN(TRIM, "RESULT: " << result)
 		}
-    
+
     return result;
   }
 
 
-  
+
   static bool parentSuperselector(const Node& one, const Node& two, Context& ctx) {
   	// TODO: figure out a better way to create a Complex_Selector from scratch
     // TODO: There's got to be a better way. This got ugly quick...
@@ -614,16 +615,16 @@ namespace Sass {
     Compound_Selector fakeHead("", noPosition, 1 /*size*/);
     fakeHead.elements().push_back(&fakeParent);
 		Complex_Selector fakeParentContainer("", noPosition, Complex_Selector::ANCESTOR_OF, &fakeHead /*head*/, NULL /*tail*/);
-    
+
     Complex_Selector* pOneWithFakeParent = nodeToComplexSelector(one, ctx);
     pOneWithFakeParent->set_innermost(&fakeParentContainer, Complex_Selector::ANCESTOR_OF);
     Complex_Selector* pTwoWithFakeParent = nodeToComplexSelector(two, ctx);
     pTwoWithFakeParent->set_innermost(&fakeParentContainer, Complex_Selector::ANCESTOR_OF);
-    
+
     return pOneWithFakeParent->is_superselector_of(pTwoWithFakeParent);
   }
 
-  
+
   class ParentSuperselectorChunker {
   public:
   	ParentSuperselectorChunker(Node& lcs, Context& ctx) : mLcs(lcs), mCtx(ctx) {}
@@ -635,7 +636,7 @@ namespace Sass {
       return parentSuperselector(seq.collection()->front(), mLcs.collection()->front(), mCtx);
     }
   };
-  
+
   class SubweaveEmptyChunker {
   public:
   	bool operator()(const Node& seq) const {
@@ -644,7 +645,7 @@ namespace Sass {
       return seq.collection()->empty();
     }
   };
-  
+
   /*
   # Takes initial subsequences of `seq1` and `seq2` and returns all
   # orderings of those subsequences. The initial subsequences are determined
@@ -684,70 +685,70 @@ namespace Sass {
     	chunk1.collection()->push_back(seq1.collection()->front());
       seq1.collection()->pop_front();
     }
-    
+
     Node chunk2 = Node::createCollection();
     while (!chunker(seq2)) {
     	chunk2.collection()->push_back(seq2.collection()->front());
       seq2.collection()->pop_front();
     }
-    
+
     if (chunk1.collection()->empty() && chunk2.collection()->empty()) {
       DEBUG_PRINTLN(CHUNKS, "RETURNING BOTH EMPTY")
       return Node::createCollection();
     }
-    
+
     if (chunk1.collection()->empty()) {
     	Node chunk2Wrapper = Node::createCollection();
     	chunk2Wrapper.collection()->push_back(chunk2);
       DEBUG_PRINTLN(CHUNKS, "RETURNING ONE EMPTY")
       return chunk2Wrapper;
     }
-    
+
     if (chunk2.collection()->empty()) {
 	    Node chunk1Wrapper = Node::createCollection();
       chunk1Wrapper.collection()->push_back(chunk1);
       DEBUG_PRINTLN(CHUNKS, "RETURNING TWO EMPTY")
       return chunk1Wrapper;
     }
-    
+
     Node perms = Node::createCollection();
-    
+
     Node firstPermutation = Node::createCollection();
     firstPermutation.collection()->insert(firstPermutation.collection()->end(), chunk1.collection()->begin(), chunk1.collection()->end());
     firstPermutation.collection()->insert(firstPermutation.collection()->end(), chunk2.collection()->begin(), chunk2.collection()->end());
     perms.collection()->push_back(firstPermutation);
-    
+
     Node secondPermutation = Node::createCollection();
     secondPermutation.collection()->insert(secondPermutation.collection()->end(), chunk2.collection()->begin(), chunk2.collection()->end());
     secondPermutation.collection()->insert(secondPermutation.collection()->end(), chunk1.collection()->begin(), chunk1.collection()->end());
     perms.collection()->push_back(secondPermutation);
-    
+
     DEBUG_PRINTLN(CHUNKS, "RETURNING PERM")
-    
+
     return perms;
   }
-  
-  
+
+
   static Node groupSelectors(Node& seq, Context& ctx) {
   	Node newSeq = Node::createCollection();
-    
+
     Node tail = Node::createCollection();
     tail.plus(seq);
-    
+
     while (!tail.collection()->empty()) {
     	Node head = Node::createCollection();
-      
+
       do {
       	head.collection()->push_back(tail.collection()->front());
         tail.collection()->pop_front();
       } while (!tail.collection()->empty() && (head.collection()->back().isCombinator() || tail.collection()->front().isCombinator()));
-      
+
       newSeq.collection()->push_back(head);
     }
-    
+
     return newSeq;
   }
-  
+
 
   static void getAndRemoveInitialOps(Node& seq, Node& ops) {
   	NodeDeque& seqCollection = *(seq.collection());
@@ -758,7 +759,7 @@ namespace Sass {
       seqCollection.pop_front();
     }
   }
-  
+
 
   static void getAndRemoveFinalOps(Node& seq, Node& ops) {
   	NodeDeque& seqCollection = *(seq.collection());
@@ -769,8 +770,8 @@ namespace Sass {
       seqCollection.pop_back();
     }
   }
-  
-  
+
+
   /*
       def merge_initial_ops(seq1, seq2)
         ops1, ops2 = [], []
@@ -791,10 +792,10 @@ namespace Sass {
   static Node mergeInitialOps(Node& seq1, Node& seq2, Context& ctx) {
   	Node ops1 = Node::createCollection();
     Node ops2 = Node::createCollection();
-    
+
   	getAndRemoveInitialOps(seq1, ops1);
     getAndRemoveInitialOps(seq2, ops2);
-    
+
 		// TODO: Do we have this information available to us?
     // newline = false
     // newline ||= !!ops1.shift if ops1.first == "\n"
@@ -803,18 +804,18 @@ namespace Sass {
 		// If neither sequence is a subsequence of the other, they cannot be merged successfully
     DefaultLcsComparator lcsDefaultComparator;
     Node opsLcs = lcs(ops1, ops2, lcsDefaultComparator, ctx);
-    
+
     if (!(opsLcs == ops1 || opsLcs == ops2)) {
     	return Node::createNil();
     }
-    
+
     // TODO: more newline logic
     // return (newline ? ["\n"] : []) + (ops1.size > ops2.size ? ops1 : ops2)
-    
+
     return (ops1.collection()->size() > ops2.collection()->size() ? ops1 : ops2);
   }
-  
-  
+
+
   /*
       def merge_final_ops(seq1, seq2, res = [])
 
@@ -880,55 +881,55 @@ namespace Sass {
       end
   */
   static Node mergeFinalOps(Node& seq1, Node& seq2, Context& ctx, Node& res) {
-    
+
     Node ops1 = Node::createCollection();
     Node ops2 = Node::createCollection();
-  
+
     getAndRemoveFinalOps(seq1, ops1);
     getAndRemoveFinalOps(seq2, ops2);
-  
+
 		// TODO: do we have newlines to remove?
     // ops1.reject! {|o| o == "\n"}
     // ops2.reject! {|o| o == "\n"}
-    
+
 		if (ops1.collection()->empty() && ops2.collection()->empty()) {
     	return res;
     }
-  
+
 		if (ops1.collection()->size() > 1 || ops2.collection()->size() > 1) {
     	DefaultLcsComparator lcsDefaultComparator;
     	Node opsLcs = lcs(ops1, ops2, lcsDefaultComparator, ctx);
-      
+
       // If there are multiple operators, something hacky's going on. If one is a supersequence of the other, use that, otherwise give up.
-      
+
       if (!(opsLcs == ops1 || opsLcs == ops2)) {
       	return Node::createNil();
       }
-      
+
       if (ops1.collection()->size() > ops2.collection()->size()) {
       	res.collection()->insert(res.collection()->begin(), ops1.collection()->rbegin(), ops1.collection()->rend());
       } else {
       	res.collection()->insert(res.collection()->begin(), ops2.collection()->rbegin(), ops2.collection()->rend());
       }
-      
+
       return res;
     }
-    
+
     if (!ops1.collection()->empty() && !ops2.collection()->empty()) {
 
     	Node op1 = ops1.collection()->front();
      	Node op2 = ops2.collection()->front();
-      
+
       Node sel1 = seq1.collection()->back();
       seq1.collection()->pop_back();
-      
+
       Node sel2 = seq2.collection()->back();
       seq2.collection()->pop_back();
 
       if (op1.combinator() == Complex_Selector::PRECEDES && op2.combinator() == Complex_Selector::PRECEDES) {
 
       	if (sel1.selector()->is_superselector_of(sel2.selector())) {
-        
+
         	res.collection()->push_front(op1 /*PRECEDES - could have been op2 as well*/);
           res.collection()->push_front(sel2);
 
@@ -941,16 +942,16 @@ namespace Sass {
 
           DEBUG_PRINTLN(ALL, "sel1: " << sel1)
           DEBUG_PRINTLN(ALL, "sel2: " << sel2)
-        
+
           Complex_Selector* pMergedWrapper = sel1.selector()->clone(ctx); // Clone the Complex_Selector to get back to something we can transform to a node once we replace the head with the unification result
           // TODO: does subject matter? Ruby: return unless merged = sel1.unify(sel2.members, sel2.subject?)
           Compound_Selector* pMerged = sel1.selector()->head()->unify_with(sel2.selector()->head(), ctx);
           pMergedWrapper->head(pMerged);
-          
+
           DEBUG_EXEC(ALL, printCompoundSelector(pMerged, "MERGED: "))
 
           Node newRes = Node::createCollection();
-          
+
           Node firstPerm = Node::createCollection();
           firstPerm.collection()->push_back(sel1);
           firstPerm.collection()->push_back(Node::createCombinator(Complex_Selector::PRECEDES));
@@ -964,14 +965,14 @@ namespace Sass {
           secondPerm.collection()->push_back(sel1);
           secondPerm.collection()->push_back(Node::createCombinator(Complex_Selector::PRECEDES));
           newRes.collection()->push_back(secondPerm);
-          
+
           if (pMerged) {
             Node mergedPerm = Node::createCollection();
             mergedPerm.collection()->push_back(Node::createSelector(pMergedWrapper, ctx));
             mergedPerm.collection()->push_back(Node::createCombinator(Complex_Selector::PRECEDES));
             newRes.collection()->push_back(mergedPerm);
           }
-          
+
           res.collection()->push_front(newRes);
 
           DEBUG_PRINTLN(ALL, "RESULT: " << res)
@@ -979,7 +980,7 @@ namespace Sass {
         }
 
       } else if (((op1.combinator() == Complex_Selector::PRECEDES && op2.combinator() == Complex_Selector::ADJACENT_TO)) || ((op1.combinator() == Complex_Selector::ADJACENT_TO && op2.combinator() == Complex_Selector::PRECEDES))) {
-      
+
       		Node tildeSel = sel1;
           Node tildeOp = op1;
           Node plusSel = sel2;
@@ -990,7 +991,7 @@ namespace Sass {
             plusSel = sel1;
             plusOp = op1;
           }
-        
+
           if (tildeSel.selector()->is_superselector_of(plusSel.selector())) {
 
             res.collection()->push_front(plusOp);
@@ -1000,70 +1001,70 @@ namespace Sass {
 
 						DEBUG_PRINTLN(ALL, "PLUS SEL: " << plusSel)
             DEBUG_PRINTLN(ALL, "TILDE SEL: " << tildeSel)
-          
+
             Complex_Selector* pMergedWrapper = plusSel.selector()->clone(ctx); // Clone the Complex_Selector to get back to something we can transform to a node once we replace the head with the unification result
             // TODO: does subject matter? Ruby: merged = plus_sel.unify(tilde_sel.members, tilde_sel.subject?)
             Compound_Selector* pMerged = plusSel.selector()->head()->unify_with(tildeSel.selector()->head(), ctx);
             pMergedWrapper->head(pMerged);
-            
+
             DEBUG_EXEC(ALL, printCompoundSelector(pMerged, "MERGED: "))
-            
+
             Node newRes = Node::createCollection();
-            
+
             Node firstPerm = Node::createCollection();
             firstPerm.collection()->push_back(tildeSel);
             firstPerm.collection()->push_back(Node::createCombinator(Complex_Selector::PRECEDES));
             firstPerm.collection()->push_back(plusSel);
             firstPerm.collection()->push_back(Node::createCombinator(Complex_Selector::ADJACENT_TO));
             newRes.collection()->push_back(firstPerm);
-            
+
             if (pMerged) {
               Node mergedPerm = Node::createCollection();
               mergedPerm.collection()->push_back(Node::createSelector(pMergedWrapper, ctx));
               mergedPerm.collection()->push_back(Node::createCombinator(Complex_Selector::ADJACENT_TO));
               newRes.collection()->push_back(mergedPerm);
             }
-            
+
             res.collection()->push_front(newRes);
-            
+
             DEBUG_PRINTLN(ALL, "RESULT: " << res)
-  
+
           }
-      } else if (op1.combinator() == Complex_Selector::PARENT_OF && (op2.combinator() == Complex_Selector::PRECEDES || op2.combinator() == Complex_Selector::ADJACENT_TO)) {
-      
+      } else if ((op1.combinator() == Complex_Selector::PARENT_OF || op1.combinator() == Complex_Selector::DEEP) && (op2.combinator() == Complex_Selector::PRECEDES || op2.combinator() == Complex_Selector::ADJACENT_TO)) {
+
       	res.collection()->push_front(op2);
         res.collection()->push_front(sel2);
-        
+
         seq2.collection()->push_back(sel1);
         seq2.collection()->push_back(op1);
 
-      } else if (op2.combinator() == Complex_Selector::PARENT_OF && (op1.combinator() == Complex_Selector::PRECEDES || op1.combinator() == Complex_Selector::ADJACENT_TO)) {
+      } else if ((op2.combinator() == Complex_Selector::PARENT_OF || op2.combinator() == Complex_Selector::DEEP) && (op1.combinator() == Complex_Selector::PRECEDES || op1.combinator() == Complex_Selector::ADJACENT_TO)) {
 
       	res.collection()->push_front(op1);
         res.collection()->push_front(sel1);
-        
+
         seq2.collection()->push_back(sel2);
         seq2.collection()->push_back(op2);
 
       } else if (op1.combinator() == op2.combinator()) {
-        
+
         DEBUG_PRINTLN(ALL, "sel1: " << sel1)
         DEBUG_PRINTLN(ALL, "sel2: " << sel2)
-      
+
         Complex_Selector* pMergedWrapper = sel1.selector()->clone(ctx); // Clone the Complex_Selector to get back to something we can transform to a node once we replace the head with the unification result
         // TODO: does subject matter? Ruby: return unless merged = sel1.unify(sel2.members, sel2.subject?)
         Compound_Selector* pMerged = sel1.selector()->head()->unify_with(sel2.selector()->head(), ctx);
         pMergedWrapper->head(pMerged);
-        
+
         DEBUG_EXEC(ALL, printCompoundSelector(pMerged, "MERGED: "))
 
         if (!pMerged) {
         	return Node::createNil();
         }
-        
+
       	res.collection()->push_front(op1);
         res.collection()->push_front(Node::createSelector(pMergedWrapper, ctx));
-        
+
         DEBUG_PRINTLN(ALL, "RESULT: " << res)
 
       } else {
@@ -1071,15 +1072,15 @@ namespace Sass {
       }
 
 			return mergeFinalOps(seq1, seq2, ctx, res);
-  
+
     } else if (!ops1.collection()->empty()) {
 
 	    Node op1 = ops1.collection()->front();
 
-    	if (op1.combinator() == Complex_Selector::PARENT_OF && !seq2.collection()->empty() && seq2.collection()->back().selector()->is_superselector_of(seq1.collection()->back().selector())) {
+    	if ((op1.combinator() == Complex_Selector::PARENT_OF || op1.combinator() == Complex_Selector::DEEP) && !seq2.collection()->empty() && seq2.collection()->back().selector()->is_superselector_of(seq1.collection()->back().selector())) {
       	seq2.collection()->pop_back();
       }
-      
+
       // TODO: consider unshift(NodeCollection, Node)
       res.collection()->push_front(op1);
       res.collection()->push_front(seq1.collection()->back());
@@ -1090,11 +1091,11 @@ namespace Sass {
     } else { // !ops2.collection()->empty()
 
     	Node op2 = ops2.collection()->front();
-      
-      if (op2.combinator() == Complex_Selector::PARENT_OF && !seq1.collection()->empty() && seq1.collection()->back().selector()->is_superselector_of(seq2.collection()->back().selector())) {
+
+      if ((op2.combinator() == Complex_Selector::PARENT_OF || op2.combinator() == Complex_Selector::DEEP) && !seq1.collection()->empty() && seq1.collection()->back().selector()->is_superselector_of(seq2.collection()->back().selector())) {
       	seq1.collection()->pop_back();
       }
-      
+
       res.collection()->push_front(op2);
       res.collection()->push_front(seq2.collection()->back());
       seq2.collection()->pop_back();
@@ -1104,8 +1105,8 @@ namespace Sass {
     }
 
   }
-  
-  
+
+
   /*
 		This is the equivalent of ruby's Sequence.subweave.
 
@@ -1155,13 +1156,13 @@ namespace Sass {
       return out;
     }
 
-    
+
 
     Node seq1 = Node::createCollection();
     seq1.plus(one);
     Node seq2 = Node::createCollection();
     seq2.plus(two);
-    
+
     DEBUG_PRINTLN(SUBWEAVE, "SUBWEAVE ONE: " << seq1)
     DEBUG_PRINTLN(SUBWEAVE, "SUBWEAVE TWO: " << seq2)
 
@@ -1169,15 +1170,15 @@ namespace Sass {
     if (init.isNil()) {
     	return Node::createNil();
     }
-    
+
     DEBUG_PRINTLN(SUBWEAVE, "INIT: " << init)
-    
+
     Node res = Node::createCollection();
 		Node fin = mergeFinalOps(seq1, seq2, ctx, res);
     if (fin.isNil()) {
     	return Node::createNil();
     }
-    
+
     DEBUG_PRINTLN(SUBWEAVE, "FIN: " << fin)
 
 
@@ -1186,9 +1187,9 @@ namespace Sass {
 
     for (NodeDeque::iterator finIter = fin.collection()->begin(), finEndIter = fin.collection()->end();
            finIter != finEndIter; ++finIter) {
-      
+
       Node& childNode = *finIter;
-      
+
       if (!childNode.isCollection()) {
       	Node wrapper = Node::createCollection();
         wrapper.collection()->push_back(childNode);
@@ -1203,7 +1204,7 @@ namespace Sass {
 
     Node groupSeq1 = groupSelectors(seq1, ctx);
     DEBUG_PRINTLN(SUBWEAVE, "SEQ1: " << groupSeq1)
-    
+
     Node groupSeq2 = groupSelectors(seq2, ctx);
     DEBUG_PRINTLN(SUBWEAVE, "SEQ2: " << groupSeq2)
 
@@ -1218,7 +1219,7 @@ namespace Sass {
     LcsCollectionComparator collectionComparator(ctx);
     lcs(groupSeq2Converted, groupSeq1Converted, collectionComparator, ctx, out);
     Node seqLcs = complexSelectorDequeToNode(out, ctx);
-    
+
     DEBUG_PRINTLN(SUBWEAVE, "SEQLCS: " << seqLcs)
 
 
@@ -1228,38 +1229,38 @@ namespace Sass {
     diff.collection()->push_back(initWrapper);
 
     DEBUG_PRINTLN(SUBWEAVE, "DIFF INIT: " << diff)
-    
-    
+
+
     while (!seqLcs.collection()->empty()) {
     	ParentSuperselectorChunker superselectorChunker(seqLcs, ctx);
       Node chunksResult = chunks(groupSeq1, groupSeq2, superselectorChunker);
       diff.collection()->push_back(chunksResult);
-      
+
       Node lcsWrapper = Node::createCollection();
       lcsWrapper.collection()->push_back(seqLcs.collection()->front());
       seqLcs.collection()->pop_front();
       diff.collection()->push_back(lcsWrapper);
-    
+
 			groupSeq1.collection()->pop_front();
       groupSeq2.collection()->pop_front();
     }
-    
+
     DEBUG_PRINTLN(SUBWEAVE, "DIFF POST LCS: " << diff)
-    
-    
+
+
     DEBUG_PRINTLN(SUBWEAVE, "CHUNKS: ONE=" << groupSeq1 << " TWO=" << groupSeq2)
-    
+
 
     SubweaveEmptyChunker emptyChunker;
     Node chunksResult = chunks(groupSeq1, groupSeq2, emptyChunker);
     diff.collection()->push_back(chunksResult);
-    
-    
+
+
     DEBUG_PRINTLN(SUBWEAVE, "DIFF POST CHUNKS: " << diff)
-    
+
 
     diff.collection()->insert(diff.collection()->end(), fin.collection()->begin(), fin.collection()->end());
-    
+
     DEBUG_PRINTLN(SUBWEAVE, "DIFF POST FIN MAPPED: " << diff)
 
     // JMA - filter out the empty nodes (use a new collection, since iterator erase() invalidates the old collection)
@@ -1272,14 +1273,14 @@ namespace Sass {
       }
     }
     diff = diffFiltered;
-    
+
     DEBUG_PRINTLN(SUBWEAVE, "DIFF POST REJECT: " << diff)
-    
-    
+
+
 		Node pathsResult = paths(diff, ctx);
-    
+
     DEBUG_PRINTLN(SUBWEAVE, "PATHS: " << pathsResult)
-    
+
 
 		// We're flattening in place
     for (NodeDeque::iterator pathsIter = pathsResult.collection()->begin(), pathsEndIter = pathsResult.collection()->end();
@@ -1288,17 +1289,17 @@ namespace Sass {
     	Node& child = *pathsIter;
       child = flatten(child, ctx);
     }
-    
+
     DEBUG_PRINTLN(SUBWEAVE, "FLATTENED: " << pathsResult)
-    
-    
+
+
     /*
       TODO: implement
       rejected = mapped.reject {|p| path_has_two_subjects?(p)}
       $stderr.puts "REJECTED: #{rejected}"
      */
-    
-  
+
+
   	return pathsResult;
 
   }
@@ -1315,18 +1316,18 @@ namespace Sass {
     } else {
       // Do the naive implementation. pOne = A B and pTwo = C D ...yields...  A B C D and C D A B
       // See https://gist.github.com/nex3/7609394 for details.
-      
+
       Node firstPerm = one.clone(ctx);
       Node twoCloned = two.clone(ctx);
       firstPerm.plus(twoCloned);
       out.collection()->push_back(firstPerm);
-      
+
       Node secondPerm = two.clone(ctx);
       Node oneCloned = one.clone(ctx);
       secondPerm.plus(oneCloned );
       out.collection()->push_back(secondPerm);
     }
-    
+
     return out;
   }
   */
@@ -1334,7 +1335,7 @@ namespace Sass {
 
   /*
    This is the equivalent of ruby's Sequence.weave.
-   
+
    The following is the modified version of the ruby code that was more portable to C++. You
    should be able to drop it into ruby 3.2.19 and get the same results from ruby sass.
 
@@ -1389,7 +1390,7 @@ namespace Sass {
               next []
             end
 
-            
+
             for seqs in sub do
               toPush = seqs + last_current
 
@@ -1406,9 +1407,9 @@ namespace Sass {
       end
   */
 	static Node weave(Node& path, Context& ctx) {
-  
+
   	DEBUG_PRINTLN(WEAVE, "WEAVE: " << path)
-  
+
   	Node befores = Node::createCollection();
     befores.collection()->push_back(Node::createCollection());
 
@@ -1419,42 +1420,42 @@ namespace Sass {
     	Node current = afters.collection()->front().clone(ctx);
       afters.collection()->pop_front();
       DEBUG_PRINTLN(WEAVE, "CURRENT: " << current)
-      
+
       Node last_current = Node::createCollection();
       last_current.collection()->push_back(current.collection()->back());
       current.collection()->pop_back();
       DEBUG_PRINTLN(WEAVE, "CURRENT POST POP: " << current)
       DEBUG_PRINTLN(WEAVE, "LAST CURRENT: " << last_current)
-    
+
 			Node tempResult = Node::createCollection();
-      
+
       for (NodeDeque::iterator beforesIter = befores.collection()->begin(), beforesEndIter = befores.collection()->end(); beforesIter != beforesEndIter; beforesIter++) {
       	Node& before = *beforesIter;
-        
+
         Node sub = subweave(before, current, ctx);
-        
+
         DEBUG_PRINTLN(WEAVE, "SUB: " << sub)
-        
+
         if (sub.isNil()) {
         	return Node::createCollection();
         }
-        
+
         for (NodeDeque::iterator subIter = sub.collection()->begin(), subEndIter = sub.collection()->end(); subIter != subEndIter; subIter++) {
           Node& seqs = *subIter;
-          
+
           Node toPush = Node::createCollection();
           toPush.plus(seqs);
           toPush.plus(last_current);
-          
+
           tempResult.collection()->push_back(toPush);
-          
+
         }
       }
-      
+
       befores = tempResult;
 
     }
-    
+
     return befores;
   }
 
@@ -1467,12 +1468,12 @@ namespace Sass {
     Context& ctx,
     ExtensionSubsetMap& subsetMap,
     set<Compound_Selector> seen);
-  
-  
-  
+
+
+
   /*
    This is the equivalent of ruby's SimpleSequence.do_extend.
-   
+
     // TODO: I think I have some modified ruby code to put here. Check.
   */
   /*
@@ -1495,27 +1496,27 @@ namespace Sass {
     Context& ctx,
     ExtensionSubsetMap& subsetMap,
     set<Compound_Selector> seen) {
-    
+
     DEBUG_EXEC(EXTEND_COMPOUND, printCompoundSelector(pSelector, "EXTEND COMPOUND: "))
-    
+
     Node extendedSelectors = Node::createCollection();
 
     To_String to_string;
 
     SubsetMapEntries entries = subsetMap.get_v(pSelector->to_str_vec());
-    
+
 
 		typedef vector<pair<Complex_Selector, vector<ExtensionPair> > > GroupedByToAResult;
-    
+
     GroupByToAFunctor<Complex_Selector> extPairKeyFunctor;
     GroupedByToAResult arr;
     group_by_to_a(entries, extPairKeyFunctor, arr);
-    
-    
+
+
     typedef pair<Compound_Selector*, Complex_Selector*> SelsNewSeqPair;
     typedef vector<SelsNewSeqPair> SelsNewSeqPairCollection;
-    
-    
+
+
     SelsNewSeqPairCollection holder;
 
 
@@ -1524,7 +1525,7 @@ namespace Sass {
 
       Complex_Selector& seq = groupedPair.first;
       vector<ExtensionPair>& group = groupedPair.second;
-      
+
 //      DEBUG_EXEC(EXTEND_COMPOUND, printComplexSelector(&seq, "SEQ: "))
 
 
@@ -1547,11 +1548,11 @@ namespace Sass {
       Compound_Selector* pExtCompoundSelector = pSels; // All the simple selectors to be replaced from the current compound selector from all extensions
 
 
-      
+
       // TODO: This can return a Compound_Selector with no elements. Should that just be returning NULL?
       Compound_Selector* pSelectorWithoutExtendSelectors = pSelector->minus(pExtCompoundSelector, ctx);
-      
-      
+
+
 //      DEBUG_EXEC(EXTEND_COMPOUND, printCompoundSelector(pSelector, "MEMBERS: "))
 //      DEBUG_EXEC(EXTEND_COMPOUND, printCompoundSelector(pSelectorWithoutExtendSelectors, "SELF_WO_SEL: "))
 
@@ -1564,21 +1565,21 @@ namespace Sass {
       }
 
       pUnifiedSelector = pInnermostCompoundSelector->unify_with(pSelectorWithoutExtendSelectors, ctx);
-      
+
 //      DEBUG_EXEC(EXTEND_COMPOUND, printCompoundSelector(pInnermostCompoundSelector, "LHS: "))
 //      DEBUG_EXEC(EXTEND_COMPOUND, printCompoundSelector(pSelectorWithoutExtendSelectors, "RHS: "))
 //      DEBUG_EXEC(EXTEND_COMPOUND, printCompoundSelector(pUnifiedSelector, "UNIFIED: "))
-      
+
       if (!pUnifiedSelector || pUnifiedSelector->length() == 0) {
         continue;
       }
-      
 
-      
+
+
       // TODO: implement the parent directive match (if necessary based on test failures)
       // next if group.map {|e, _| check_directives_match!(e, parent_directives)}.none?
-      
-      
+
+
 
 
       // TODO: This seems a little fishy to me. See if it causes any problems. From the ruby, we should be able to just
@@ -1589,7 +1590,7 @@ namespace Sass {
       Complex_Selector* pNewInnerMost = new (ctx.mem) Complex_Selector(pSelector->path(), pSelector->position(), Complex_Selector::ANCESTOR_OF, pUnifiedSelector, NULL);
       Complex_Selector::Combinator combinator = pNewSelector->clear_innermost();
       pNewSelector->set_innermost(pNewInnerMost, combinator);
-      
+
 #ifdef DEBUG
 			SourcesSet debugSet;
       debugSet = pNewSelector->sources();
@@ -1601,12 +1602,12 @@ namespace Sass {
       	throw "The extension selector from our subset map should not have sources. These will bleed to the new selector. Something needs to be cloned to fix this.";
       }
 #endif
-      
-      
+
+
 
       // Set the sources on our new Complex_Selector to the sources of this simple sequence plus the thing we're extending.
       DEBUG_PRINTLN(EXTEND_COMPOUND, "SOURCES SETTING ON NEW SEQ: " << complexSelectorToNode(pNewSelector, ctx))
-      
+
       DEBUG_EXEC(EXTEND_COMPOUND, SourcesSet oldSet = pNewSelector->sources(); printSourcesSet(oldSet, ctx, "SOURCES NEW SEQ BEGIN: "))
 
       SourcesSet newSourcesSet = pSelector->sources();
@@ -1616,7 +1617,7 @@ namespace Sass {
       DEBUG_EXEC(EXTEND_COMPOUND, printSourcesSet(newSourcesSet, ctx, "SOURCES WITH NEW SOURCE: "))
 
       pNewSelector->addSources(newSourcesSet, ctx);
-      
+
 			DEBUG_EXEC(EXTEND_COMPOUND, SourcesSet newSet = pNewSelector->sources(); printSourcesSet(newSet, ctx, "SOURCES ON NEW SELECTOR AFTER ADD: "))
       DEBUG_EXEC(EXTEND_COMPOUND, printSourcesSet(pSelector->sources(), ctx, "SOURCES THIS EXTEND WHICH SHOULD BE SAME STILL: "))
 
@@ -1628,15 +1629,15 @@ namespace Sass {
 
     for (SelsNewSeqPairCollection::iterator holderIter = holder.begin(), holderIterEnd = holder.end(); holderIter != holderIterEnd; holderIter++) {
 			SelsNewSeqPair& pair = *holderIter;
-      
+
       Compound_Selector* pSels = pair.first;
       Complex_Selector* pNewSelector = pair.second;
-      
+
 
       if (seen.find(*pSels) != seen.end()) {
         continue;
       }
-      
+
 
       set<Compound_Selector> recurseSeen(seen);
       recurseSeen.insert(*pSels);
@@ -1645,7 +1646,7 @@ namespace Sass {
 			DEBUG_PRINTLN(EXTEND_COMPOUND, "RECURSING DO EXTEND: " << complexSelectorToNode(pNewSelector, ctx))
 
 			Node recurseExtendedSelectors = extendComplexSelector(pNewSelector, ctx, subsetMap, recurseSeen);
-      
+
 			DEBUG_PRINTLN(EXTEND_COMPOUND, "RECURSING DO EXTEND RETURN: " << recurseExtendedSelectors)
 
       for (NodeDeque::iterator iterator = recurseExtendedSelectors.collection()->begin(), endIterator = recurseExtendedSelectors.collection()->end();
@@ -1661,13 +1662,13 @@ namespace Sass {
         }
       }
     }
-    
+
     DEBUG_EXEC(EXTEND_COMPOUND, printCompoundSelector(pSelector, "EXTEND COMPOUND END: "))
-    
+
     return extendedSelectors;
   }
-  
-  
+
+
   static bool complexSelectorHasExtension(
   	Complex_Selector* pComplexSelector,
     Context& ctx,
@@ -1676,26 +1677,26 @@ namespace Sass {
 		bool hasExtension = false;
 
 		Complex_Selector* pIter = pComplexSelector;
-    
+
     while (!hasExtension && pIter) {
     	Compound_Selector* pHead = pIter->head();
 
 			if (pHead) {
         SubsetMapEntries entries = subsetMap.get_v(pHead->to_str_vec());
-        
+
         hasExtension = entries.size() > 0;
       }
 
     	pIter = pIter->tail();
     }
-    
+
     return hasExtension;
   }
 
-  
+
   /*
    This is the equivalent of ruby's Sequence.do_extend.
-   
+
    // TODO: I think I have some modified ruby code to put here. Check.
    */
   /*
@@ -1709,18 +1710,18 @@ namespace Sass {
     Context& ctx,
     ExtensionSubsetMap& subsetMap,
     set<Compound_Selector> seen) {
-    
+
     Node complexSelector = complexSelectorToNode(pComplexSelector, ctx);
- 
+
     DEBUG_PRINTLN(EXTEND_COMPLEX, "EXTEND COMPLEX: " << complexSelector)
-    
+
     Node extendedNotExpanded = Node::createCollection();
-    
+
     for (NodeDeque::iterator complexSelIter = complexSelector.collection()->begin(), complexSelIterEnd = complexSelector.collection()->end(); complexSelIter != complexSelIterEnd; ++complexSelIter) {
       Node& sseqOrOp = *complexSelIter;
-      
+
       DEBUG_PRINTLN(EXTEND_COMPLEX, "LOOP: " << sseqOrOp)
-      
+
       // If it's not a selector (meaning it's a combinator), just include it automatically
       if (!sseqOrOp.isSelector()) {
       	// Wrap our Combinator in two collections to match ruby. This is essentially making a collection Node
@@ -1732,14 +1733,14 @@ namespace Sass {
         extendedNotExpanded.collection()->push_back(outer);
       	continue;
       }
-    
+
       Compound_Selector* pCompoundSelector = sseqOrOp.selector()->head();
 
       Node extended = extendCompoundSelector(pCompoundSelector, ctx, subsetMap, seen);
 
 			DEBUG_PRINTLN(EXTEND_COMPLEX, "EXTENDED: " << extended)
 
-      
+
       // Prepend the Compound_Selector based on the choices logic; choices seems to be extend but with an ruby Array instead of a Sequence
       // due to the member mapping: choices = extended.map {|seq| seq.members}
       Complex_Selector* pJustCurrentCompoundSelector = sseqOrOp.selector();
@@ -1760,15 +1761,15 @@ namespace Sass {
       }
 
 			DEBUG_PRINTLN(EXTEND_COMPLEX, "CHOICES UNSHIFTED: " << extended)
-      
+
       // Aggregate our current extensions
       extendedNotExpanded.collection()->push_back(extended);
     }
 
 
 		DEBUG_PRINTLN(EXTEND_COMPLEX, "EXTENDED NOT EXPANDED: " << extendedNotExpanded)
-  
-  
+
+
 
     // Ruby Equivalent: paths
     Node paths = Sass::paths(extendedNotExpanded, ctx);
@@ -1779,7 +1780,7 @@ namespace Sass {
 
     // Ruby Equivalent: weave
     Node weaves = Node::createCollection();
-    
+
     for (NodeDeque::iterator pathsIter = paths.collection()->begin(), pathsEndIter = paths.collection()->end(); pathsIter != pathsEndIter; ++pathsIter) {
       Node& path = *pathsIter;
 			Node weaved = weave(path, ctx);
@@ -1795,13 +1796,13 @@ namespace Sass {
 
 		DEBUG_PRINTLN(EXTEND_COMPLEX, "TRIMMED: " << trimmed)
 
-    
+
     // Ruby Equivalent: flatten
     Node extendedSelectors = flatten(trimmed, ctx, 1);
-    
+
 		DEBUG_PRINTLN(EXTEND_COMPLEX, ">>>>> EXTENDED: " << extendedSelectors)
-    
-    
+
+
     DEBUG_PRINTLN(EXTEND_COMPLEX, "EXTEND COMPLEX END: " << complexSelector)
 
 
@@ -1818,12 +1819,12 @@ namespace Sass {
     To_String to_string;
 
     Selector_List* pNewSelectors = new (ctx.mem) Selector_List(pSelectorList->path(), pSelectorList->position(), pSelectorList->length());
-    
+
     extendedSomething = false;
 
     for (size_t index = 0, length = pSelectorList->length(); index < length; index++) {
       Complex_Selector* pSelector = (*pSelectorList)[index];
-      
+
       // ruby sass seems to keep a list of things that have extensions and then only extend those. We don't currently do that.
       // Since it's not that expensive to check if an extension exists in the subset map and since it can be relatively expensive to
       // run through the extend code (which does a data model transformation), check if there is anything to extend before doing
@@ -1833,31 +1834,31 @@ namespace Sass {
       	*pNewSelectors << pSelector;
       	continue;
       }
-      
+
       extendedSomething = true;
 
       set<Compound_Selector> seen;
       Node extendedSelectors = extendComplexSelector(pSelector, ctx, subsetMap, seen);
-      
+
       if (!pSelector->has_placeholder()) {
         if (!extendedSelectors.contains(complexSelectorToNode(pSelector, ctx), true /*simpleSelectorOrderDependent*/)) {
         	*pNewSelectors << pSelector;
         }
       }
-      
+
       for (NodeDeque::iterator iterator = extendedSelectors.collection()->begin(), iteratorEnd = extendedSelectors.collection()->end(); iterator != iteratorEnd; ++iterator) {
         Node& childNode = *iterator;
         *pNewSelectors << nodeToComplexSelector(childNode, ctx);
       }
     }
-    
+
     return pNewSelectors;
 
   }
-  
+
 
   bool shouldExtendBlock(Block* b) {
-  
+
   	// If a block is empty, there's no reason to extend it since any rules placed on this block
     // won't have any output. The main benefit of this is for structures like:
     //
@@ -1870,7 +1871,7 @@ namespace Sass {
     // We end up visiting two rulesets (one with the selector .a and the other with the selector .a .b).
     // In this case, we don't want to try to pull rules onto .a since they won't get output anyway since
     // there are no child statements. However .a .b should have extensions applied.
-    
+
     for (size_t i = 0, L = b->length(); i < L; ++i) {
       Statement* stm = (*b)[i];
 
@@ -1881,19 +1882,19 @@ namespace Sass {
         return true;
       }
     }
-    
+
     return false;
 
   }
 
-  
+
   // Extend a ruleset by extending the selectors and updating them on the ruleset. The block's rules don't need to change.
   template <typename ObjectType>
   static void extendObjectWithSelectorAndBlock(ObjectType* pObject, Context& ctx, ExtensionSubsetMap& subsetMap) {
     To_String to_string;
-    
+
     DEBUG_PRINTLN(EXTEND_OBJECT, "FOUND SELECTOR: " << static_cast<Selector_List*>(pObject->selector())->perform(&to_string))
-    
+
     // Ruby sass seems to filter nodes that don't have any content well before we get here. I'm not sure the repercussions
     // of doing so, so for now, let's just not extend things that won't be output later.
     if (!shouldExtendBlock(pObject->block())) {
@@ -1923,8 +1924,8 @@ namespace Sass {
       DEBUG_PRINTLN(EXTEND_OBJECT, "EXTEND DID NOT TRY TO EXTEND ANYTHING")
     }
   }
-  
-  
+
+
 
   Extend::Extend(Context& ctx, ExtensionSubsetMap& ssm)
   : ctx(ctx), subset_map(ssm)
@@ -1949,7 +1950,7 @@ namespace Sass {
     if (pMediaBlock->selector()) {
       extendObjectWithSelectorAndBlock(pMediaBlock, ctx, subset_map);
     }
-    
+
     pMediaBlock->block()->perform(this);
   }
 

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -570,6 +570,7 @@ namespace Sass {
       case Complex_Selector::PARENT_OF:   append_to_buffer(">"); break;
       case Complex_Selector::PRECEDES:    append_to_buffer("~"); break;
       case Complex_Selector::ADJACENT_TO: append_to_buffer("+"); break;
+      case Complex_Selector::DEEP:        append_to_buffer("/deep/"); break;
     }
     if (tail && comb != Complex_Selector::ANCESTOR_OF) {
       append_to_buffer(" ");

--- a/node.cpp
+++ b/node.cpp
@@ -11,43 +11,43 @@ namespace Sass {
     return Node(COMBINATOR, combinator, NULL /*pSelector*/, null /*pCollection*/);
   }
 
-    
+
   Node Node::createSelector(Complex_Selector* pSelector, Context& ctx) {
     NodeDequePtr null;
 
     Complex_Selector* pStripped = pSelector->clone(ctx);
     pStripped->tail(NULL);
     pStripped->combinator(Complex_Selector::ANCESTOR_OF);
-    
+
     return Node(SELECTOR, Complex_Selector::ANCESTOR_OF, pStripped, null /*pCollection*/);
   }
 
-    
+
   Node Node::createCollection() {
     NodeDequePtr pEmptyCollection = make_shared<NodeDeque>();
     return Node(COLLECTION, Complex_Selector::ANCESTOR_OF, NULL /*pSelector*/, pEmptyCollection);
   }
 
-    
+
   Node Node::createCollection(const NodeDeque& values) {
     NodeDequePtr pShallowCopiedCollection = make_shared<NodeDeque>(values);
     return Node(COLLECTION, Complex_Selector::ANCESTOR_OF, NULL /*pSelector*/, pShallowCopiedCollection);
   }
 
-    
+
   Node Node::createNil() {
     NodeDequePtr null;
     return Node(NIL, Complex_Selector::ANCESTOR_OF, NULL /*pSelector*/, null /*pCollection*/);
   }
 
-  
+
   Node::Node(const TYPE& type, Complex_Selector::Combinator combinator, Complex_Selector* pSelector, NodeDequePtr& pCollection) :
   	mType(type),
     mCombinator(combinator),
     mpSelector(pSelector),
     mpCollection(pCollection) {}
 
-  
+
   Node Node::clone(Context& ctx) const {
     NodeDequePtr pNewCollection = make_shared<NodeDeque>();
     if (mpCollection) {
@@ -56,14 +56,14 @@ namespace Sass {
         pNewCollection->push_back(toClone.clone(ctx));
       }
     }
-    
+
     return Node(mType, mCombinator, mpSelector ? mpSelector->clone(ctx) : NULL, pNewCollection);
   }
-  
-  
+
+
   bool Node::contains(const Node& potentialChild, bool simpleSelectorOrderDependent) const {
   	bool found = false;
-    
+
     for (NodeDeque::iterator iter = mpCollection->begin(), iterEnd = mpCollection->end(); iter != iterEnd; iter++) {
       Node& toTest = *iter;
 
@@ -75,18 +75,18 @@ namespace Sass {
 
     return found;
   }
-  
+
 
   bool Node::operator==(const Node& rhs) const {
   	return nodesEqual(*this, rhs, true /*simpleSelectorOrderDependent*/);
   }
-  
+
 
   bool nodesEqual(const Node& lhs, const Node& rhs, bool simpleSelectorOrderDependent) {
     if (lhs.type() != rhs.type()) {
       return false;
     }
-    
+
     if (lhs.isCombinator()) {
 
     	return lhs.combinator() == rhs.combinator();
@@ -117,20 +117,20 @@ namespace Sass {
       return true;
 
     }
-    
+
     // We shouldn't get here.
     throw "Comparing unknown node types. A new type was probably added and this method wasn't implemented for it.";
   }
-  
-  
+
+
   void Node::plus(Node& rhs) {
   	if (!this->isCollection() || !rhs.isCollection()) {
     	throw "Both the current node and rhs must be collections.";
     }
   	this->collection()->insert(this->collection()->end(), rhs.collection()->begin(), rhs.collection()->end());
   }
-  
-  
+
+
   ostream& operator<<(ostream& os, const Node& node) {
 
     if (node.isCombinator()) {
@@ -140,21 +140,22 @@ namespace Sass {
         case Complex_Selector::PARENT_OF:   os << "\">\""; break;
         case Complex_Selector::PRECEDES:    os << "\"~\""; break;
         case Complex_Selector::ADJACENT_TO: os << "\"+\""; break;
+        case Complex_Selector::DEEP:        os << "\"/deep/\""; break;
       }
-      
+
     } else if (node.isNil()) {
-      
+
       os << "nil";
-      
+
     } else if (node.isSelector()){
-      
+
       To_String to_string;
       os << node.selector()->head()->perform(&to_string);
-      
+
     } else if (node.isCollection()) {
-      
+
 			os << "[";
-      
+
       for (NodeDeque::iterator iter = node.collection()->begin(), iterBegin = node.collection()->begin(), iterEnd = node.collection()->end(); iter != iterEnd; iter++) {
         if (iter != iterBegin) {
           os << ", ";
@@ -162,23 +163,23 @@ namespace Sass {
 
 				os << (*iter);
       }
-      
+
       os << "]";
-      
+
     }
-    
+
     return os;
 
   }
-  
-  
+
+
   Node complexSelectorToNode(Complex_Selector* pToConvert, Context& ctx) {
     if (pToConvert == NULL) {
       return Node::createNil();
     }
 
 		Node node = Node::createCollection();
-    
+
     while (pToConvert) {
 
       // the first Complex_Selector may contain a dummy head pointer, skip it.
@@ -192,7 +193,7 @@ namespace Sass {
 
       pToConvert = pToConvert->tail();
     }
-    
+
     return node;
   }
 
@@ -206,25 +207,25 @@ namespace Sass {
     if (!toConvert.isCollection()) {
       throw "The node to convert to a Complex_Selector* must be a collection type or nil.";
     }
-    
+
 
     NodeDeque& childNodes = *toConvert.collection();
-    
+
     string noPath("");
     Position noPosition;
     Complex_Selector* pFirst = new (ctx.mem) Complex_Selector(noPath, noPosition, Complex_Selector::ANCESTOR_OF, NULL, NULL);
     Complex_Selector* pCurrent = pFirst;
-    
+
     for (NodeDeque::iterator childIter = childNodes.begin(), childIterEnd = childNodes.end(); childIter != childIterEnd; childIter++) {
 
       Node& child = *childIter;
-      
+
       if (child.isSelector()) {
         pCurrent->tail(child.selector()->clone(ctx));   // JMA - need to clone the selector, because they can end up getting shared across Node collections, and can result in an infinite loop during the call to parentSuperselector()
         pCurrent = pCurrent->tail();
       } else if (child.isCombinator()) {
         pCurrent->combinator(child.combinator());
-        
+
         // if the next node is also a combinator, create another Complex_Selector to hold it so it doesn't replace the current combinator
         if (childIter+1 != childIterEnd) {
           Node& nextNode = *(childIter+1);
@@ -243,7 +244,7 @@ namespace Sass {
     Selector_Reference* selectorRef = new (ctx.mem) Selector_Reference(noPath, noPosition, NULL);
     fakeHead->elements().push_back(selectorRef);
     pFirst->head(fakeHead);
-    
+
     return pFirst;
   }
 

--- a/output_compressed.cpp
+++ b/output_compressed.cpp
@@ -86,7 +86,7 @@ namespace Sass {
       }
       return;
     }
-    
+
     ctx->source_map.add_mapping(m);
     append_singleline_part_to_buffer("@media ");
     q->perform(this);
@@ -104,9 +104,9 @@ namespace Sass {
           stm->perform(this);
         }
       }
-      
+
       append_singleline_part_to_buffer("}");
-      
+
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         Statement* stm = (*b)[i];
         if (stm->is_hoistable()) {
@@ -273,7 +273,7 @@ namespace Sass {
     {
       tail->perform(this);
       return;
-    } 
+    }
     if (head && !head->is_empty_reference()) head->perform(this);
     switch (comb) {
       case Complex_Selector::ANCESTOR_OF:
@@ -290,6 +290,9 @@ namespace Sass {
         break;
       case Complex_Selector::ADJACENT_TO:
         append_singleline_part_to_buffer("+");
+        break;
+      case Complex_Selector::DEEP:
+        append_singleline_part_to_buffer("/deep/");
         break;
     }
     if (tail) tail->perform(this);

--- a/parser.cpp
+++ b/parser.cpp
@@ -377,9 +377,10 @@ namespace Sass {
   {
     Position sel_source_position = Position();
     Compound_Selector* lhs;
-    if (peek< exactly<'+'> >() ||
-        peek< exactly<'~'> >() ||
-        peek< exactly<'>'> >()) {
+    if (peek< exactly<'+'> >()    ||
+        peek< exactly<'~'> >()    ||
+        peek< exactly<'>'> >()    ||
+        peek< deep_combinator >()) {
       // no selector before the combinator
       lhs = 0;
     }
@@ -389,10 +390,11 @@ namespace Sass {
     }
 
     Complex_Selector::Combinator cmb;
-    if      (lex< exactly<'+'> >()) cmb = Complex_Selector::ADJACENT_TO;
-    else if (lex< exactly<'~'> >()) cmb = Complex_Selector::PRECEDES;
-    else if (lex< exactly<'>'> >()) cmb = Complex_Selector::PARENT_OF;
-    else                            cmb = Complex_Selector::ANCESTOR_OF;
+    if      (lex< deep_combinator >()) cmb = Complex_Selector::DEEP;
+    else if (lex< exactly<'+'> >())    cmb = Complex_Selector::ADJACENT_TO;
+    else if (lex< exactly<'~'> >())    cmb = Complex_Selector::PRECEDES;
+    else if (lex< exactly<'>'> >())    cmb = Complex_Selector::PARENT_OF;
+    else                               cmb = Complex_Selector::ANCESTOR_OF;
 
     Complex_Selector* rhs;
     if (peek< exactly<','> >() ||
@@ -439,13 +441,14 @@ namespace Sass {
     }
 
     while (!peek< spaces >(position) &&
-           !(peek < exactly<'+'> >(position) ||
-             peek < exactly<'~'> >(position) ||
-             peek < exactly<'>'> >(position) ||
-             peek < exactly<','> >(position) ||
-             peek < exactly<')'> >(position) ||
-             peek < exactly<'{'> >(position) ||
-             peek < exactly<'}'> >(position) ||
+           !(peek < exactly<'+'> >(position)    ||
+             peek < exactly<'~'> >(position)    ||
+             peek < exactly<'>'> >(position)    ||
+             peek < deep_combinator >(position) ||
+             peek < exactly<','> >(position)    ||
+             peek < exactly<')'> >(position)    ||
+             peek < exactly<'{'> >(position)    ||
+             peek < exactly<'}'> >(position)    ||
              peek < exactly<';'> >(position))) {
       (*seq) << parse_simple_selector();
     }
@@ -589,14 +592,14 @@ namespace Sass {
     bool semicolon = false;
     Selector_Lookahead lookahead_result;
     Block* block = new (ctx.mem) Block(path, source_position);
-    
-    // JMA - ensure that a block containing only block_comments is parsed 
+
+    // JMA - ensure that a block containing only block_comments is parsed
     while (lex< block_comment >()) {
       String*  contents = parse_interpolated_chunk(lexed);
       Comment* comment  = new (ctx.mem) Comment(path, source_position, contents);
       (*block) << comment;
     }
-    
+
     while (!lex< exactly<'}'> >()) {
       if (semicolon) {
         if (!lex< exactly<';'> >()) {
@@ -1588,6 +1591,7 @@ namespace Sass {
            (q = peek< exactly<'+'> >(p))                           ||
            (q = peek< exactly<'~'> >(p))                           ||
            (q = peek< exactly<'>'> >(p))                           ||
+           (q = peek< deep_combinator >(p))                        ||
            (q = peek< exactly<','> >(p))                           ||
            (q = peek< binomial >(p))                               ||
            (q = peek< sequence< optional<sign>,
@@ -1644,6 +1648,7 @@ namespace Sass {
            (q = peek< exactly<'+'> >(p))                           ||
            (q = peek< exactly<'~'> >(p))                           ||
            (q = peek< exactly<'>'> >(p))                           ||
+           (q = peek< deep_combinator >(p))                        ||
            (q = peek< exactly<','> >(p))                           ||
            (q = peek< binomial >(p))                               ||
            (q = peek< sequence< optional<sign>,

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -92,7 +92,7 @@ namespace Sass {
         if((p = escape(src))) {
           src = p;
           continue;
-        } 
+        }
         else if((p = exactly<'"'>(src))) {
           return p;
         }
@@ -111,7 +111,7 @@ namespace Sass {
         if((p = escape(src))) {
           src = p;
           continue;
-        } 
+        }
         else if((p = exactly<'\''>(src))) {
           return p;
         }
@@ -322,7 +322,7 @@ namespace Sass {
     }
     // Attribute name in an attribute selector.
     const char* attribute_name(const char* src) {
-      return alternatives< sequence< optional<namespace_prefix>, identifier>, 
+      return alternatives< sequence< optional<namespace_prefix>, identifier>,
                            identifier >(src);
     }
     // match placeholder selectors
@@ -460,6 +460,9 @@ namespace Sass {
     }
     const char* ancestor_of(const char* src) {
       return sequence< spaces, negate< exactly<'{'> > >(src);
+    }
+    const char* deep_combinator(const char* src) {
+      return sequence< optional_spaces, exactly<deep_combinator_kwd> >(src);
     }
 
     // Match SCSS variable names.

--- a/prelexer.hpp
+++ b/prelexer.hpp
@@ -421,6 +421,7 @@ namespace Sass {
     const char* precedes(const char* src);
     const char* parent_of(const char* src);
     const char* ancestor_of(const char* src);
+    const char* deep_combinator(const char* src);
 
     // Match SCSS variable names.
     const char* variable(const char* src);


### PR DESCRIPTION
> This PR prevents libsass from barfing when it encounters the [reference combinator](http://www.w3.org/TR/selectors4/#idref-combinators) from CSS Selectors Level 4. 
> 
> Fixes sass/libsass#452. Spec added sass/sass-spec#57.
> ### A couple things to note
> 
> For intents and purposes the /deep/ combinator acts like the direct sibling combinator except for the shadow dom. [3.2.4 Selecting Through Shadows: the /deep/ combinator](http://dev.w3.org/csswg/css-scoping/#deep-combinator).
### Note

This is still heavily a work in progress. A PR will be opened against sass/libsass when ready.
